### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/graphite-api.gemspec
+++ b/graphite-api.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.homepage              = 'http://www.kontera.com'
   s.license               = 'LGPL-3.0'
   s.required_ruby_version = '>= 2.3'
-  s.rubyforge_project     = "graphite-api"
   s.files                 = %w(LICENSE README.md Rakefile) + Dir.glob("{lib,test,tasks}/**/*")
   s.require_path          = "lib"
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.